### PR TITLE
images/Dockerfile-buildspace: add kas and pwclient

### DIFF
--- a/images/Dockerfile-buildspace
+++ b/images/Dockerfile-buildspace
@@ -71,9 +71,12 @@ RUN \
     rm -rf /var/cache/dnf && \
     rm -rf /usr/share/{man,doc,info,gnome/help} && \
     rm -rf /usr/share/texlive/texmf-dist/{fonts,doc,tex} && \
+    pip install kas pwclient && \
     cd /usr/libexec/git-core && \
     find . -samefile git -name 'git-*' -exec ln -sf git {} \; && \
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+COPY pwclientrc /home/builder/.pwclientrc
 
 USER builder
 

--- a/images/pwclientrc
+++ b/images/pwclientrc
@@ -1,0 +1,13 @@
+
+# Sample .pwclientrc file for the oe project,
+# running on patchwork.openembedded.org.
+#
+# Just append this file to your existing ~/.pwclientrc
+# If you do not already have a ~/.pwclientrc, then copy this file to
+# ~/.pwclientrc, and uncomment the following two lines:
+[options]
+default=oe
+signoff=True
+
+[oe]
+url= https://patchwork.openembedded.org/xmlrpc/


### PR DESCRIPTION
You can now run:

docker run --rm threexc/yocto-build pwclient list -p oe \
       -s New meta-python
or

docker run --rm threexc/yocto-build kas --help

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>